### PR TITLE
请升级org.apache.logging.log4j:log4j-core组件版本以解决5个安全漏洞

### DIFF
--- a/agent/plugins/logger-plugin/pom.xml
+++ b/agent/plugins/logger-plugin/pom.xml
@@ -22,7 +22,7 @@
     <slf4j.version>1.7.32</slf4j.version>
     <log4j.version>1.2.17</log4j.version>
     <!-- need to update instrumentation for 2.12.1+ !! -->
-    <log4j2x.version>2.12.0</log4j2x.version>
+    <log4j2x.version>2.20.0</log4j2x.version>
     <commons.logging.version>1.2</commons.logging.version>
     <!-- JBoss Logging 2.1+ requires Java 8+ -->
     <jboss.logging.version>2.0.11.Final</jboss.logging.version>


### PR DESCRIPTION
将 **org.apache.logging.log4j:log4j-core** 组件从2.12.0 版本升级至 2.20.0版本,
用于修复以下安全漏洞：


序号 | 漏洞编号 | 漏洞标题 | 漏洞级别
-- | -- | -- | --
1 | [MPS-2021-38241](https://www.oscs1024.com/hd/MPS-2021-38241) | Apache Log4j2 远程代码执行漏洞 | 严重
2 | [MPS-2020-6684](https://www.oscs1024.com/hd/MPS-2020-6684) | Apache Log4j2 SmtpAppender证书验证不当漏洞 | 低危
3 | [MPS-2021-38327](https://www.oscs1024.com/hd/MPS-2021-38327) | Apache Log4j2 JDBC Appender远程代码执行漏洞 | 中危
4 | [MPS-2021-38665](https://www.oscs1024.com/hd/MPS-2021-38665) | Apache Log4j2 基于上下文查找的远程代码执行漏洞 | 严重
5 | [MPS-2021-38752](https://www.oscs1024.com/hd/MPS-2021-38752) | Apache Log4j2 自引用拒绝服务漏洞 | 中危
  |   |   |   


<br/>

_注意 ：此 PR 由您（或拥有此仓库权限的其他维护者）授权 [墨菲安全](https://www.murphysec.com) 打开_

了解更多：
- [如何快速修复代码安全问题](https://www.murphysec.com/docs/faqs/security-issues/how-to-quick-fixes.html)
